### PR TITLE
Corrected Script to be global instead of local

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,4 +1,4 @@
-local ContainerFramework = {}
+ContainerFramework = {}
 
 ContainerFramework.scriptName = "ContainerFramework"
 


### PR DESCRIPTION
first line declared script functions local. Removed local declare. Functions can now be called from other scripts, such as CustomAlchemy